### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/src/pdfgen.c
+++ b/src/pdfgen.c
@@ -2044,7 +2044,8 @@ static int jpeg_size(unsigned char *data, unsigned int data_size, int *width,
                     return 0;
                 }
                 i += 2;
-                block_length = data[i] * 256 + data[i + 1];
+                if (i + 1 < data_size)
+                    block_length = data[i] * 256 + data[i+1];
             }
         }
     }

--- a/src/stb_image.h
+++ b/src/stb_image.h
@@ -2987,6 +2987,13 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
       if (z->img_comp[i].v > v_max) v_max = z->img_comp[i].v;
    }
 
+   // check that plane subsampling factors are integer ratios; our resamplers can't deal with fractional ratios
+   // and I've never seen a non-corrupted JPEG file actually use them
+   for (i=0; i < s->img_n; ++i) {
+      if (h_max % z->img_comp[i].h != 0) return stbi__err("bad H","Corrupt JPEG");
+      if (v_max % z->img_comp[i].v != 0) return stbi__err("bad V","Corrupt JPEG");
+   }
+
    // compute interleaved mcu info
    z->img_h_max = h_max;
    z->img_v_max = v_max;


### PR DESCRIPTION


This PR fixes a potential security vulnerability in `src/pdfgen.c` that was cloned from `https://github.com/AndreRenaud/PDFGen` but did not receive the security patch.

### Details:
Affected File(s): 
- src/pdfgen.c

Original Fix: https://github.com/AndreRenaud/PDFGen/commit/ee58aff6918b8bbc3be29b9e3089485ea46ff956

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/AndreRenaud/PDFGen/commit/ee58aff6918b8bbc3be29b9e3089485ea46ff956
- https://nvd.nist.gov/vuln/detail/CVE-2018-11363

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.

